### PR TITLE
remove dependency on react-native which will break the packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "invariant": "2.1.1",
-    "react-native": ">=0.9.0 <0.13.0",
     "gl-react-core": "1.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Starting on 0.13, duplicated modules throw packager warnings. By having a nested react-native dependency, these warnings pop up often, and may eventually break the packager. So best to stick with peerDeps only. This is the trend followed by most other packages now, anyway.
