### PR TITLE
Add profiling for render method

### DIFF
--- a/ios/GLCanvas.m
+++ b/ios/GLCanvas.m
@@ -4,6 +4,7 @@
 #import "RCTConvert.h"
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
+#import "RCTProfile.h"
 #import "RNGLContext.h"
 #import "GLCanvas.h"
 #import "GLShader.h"
@@ -320,7 +321,9 @@ RCT_NOT_IMPLEMENTED(-init)
     });
   }
   else {
+    RCTProfileBeginEvent(0, @"GLCanvas render", nil);
     [self render];
+    RCTProfileEndEvent(0, @"gl", nil);
     _deferredRendering = false;
     
     unsigned long nbCaptureListeners = [_captureListeners count];


### PR DESCRIPTION
This PR add perfomance measuring for GLCanvas render method. 

I'm profiling a shader for old A5 devices and ability to use special internal tooling provided by React Native allows me to watch the degradation of perfomance. In this particular screenshot it's super slow, the app is basically unresponsive, but there are other cases where it's "almost fine" but frames per second is still not ideal.  
![image](https://cloud.githubusercontent.com/assets/1004115/11502480/ec4c72dc-985c-11e5-9159-c99e0377caee.png)
