### PR TITLE
Don't force GLSurfaceView to render over native views

### DIFF
--- a/android/src/main/java/com/projectseptember/RNGL/GLCanvas.java
+++ b/android/src/main/java/com/projectseptember/RNGL/GLCanvas.java
@@ -89,7 +89,7 @@ public class GLCanvas extends GLSurfaceView
 
         setEGLConfigChooser(8, 8, 8, 8, 16, 0);
         getHolder().setFormat(PixelFormat.RGB_888);
-        setZOrderOnTop(true);
+        setZOrderOnTop(false);
 
         setRenderer(this);
         setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);


### PR DESCRIPTION
Allow native views to render on top of GLSurfaceView
