### PR TITLE
add podspec file

### DIFF
--- a/RNGL.podspec
+++ b/RNGL.podspec
@@ -1,0 +1,10 @@
+Pod::Spec.new do |s|
+
+  s.name         = "RNGL"
+  s.version      = "2.20.1"
+  s.homepage     = "https://github.com/ProjectSeptemberInc/gl-react-native"
+  s.platform     = :ios, "8.0"
+  s.source       = { :git => "https://github.com/ProjectSeptemberInc/gl-react-native.git" }
+  s.source_files = 'ios/*.{h,m}'
+
+end


### PR DESCRIPTION
Add a cocoapods podspec file, so it can be included in a Podfile with: 
`pod 'RNGL', :path => './node_modules/gl-react-native'`
