### PR TITLE
[android] Set transparent background.

### DIFF
--- a/android/src/main/java/com/projectseptember/RNGL/GLCanvasManager.java
+++ b/android/src/main/java/com/projectseptember/RNGL/GLCanvasManager.java
@@ -52,6 +52,16 @@ public class GLCanvasManager extends SimpleViewManager<GLCanvas> {
         view.setZOrderMediaOverlay(overlay);
     }
 
+    @ReactProp(name = "setZOrderOnTop")
+    public void setZOrderOnTop (GLCanvas view, boolean setZOrderOnTop) {
+        view.setZOrderOnTop(setZOrderOnTop);
+    }
+
+    @ReactProp(name = "backgroundColor")
+    public void setBackgroundColor (GLCanvas view, Integer color) {
+        view.setBackgroundColor(color);
+    }
+
     @ReactProp(name = "pointerEvents")
     public void setPointerEvents(GLCanvas view, @Nullable String pointerEventsStr) {
         if (pointerEventsStr != null) {

--- a/src/GLCanvas.js
+++ b/src/GLCanvas.js
@@ -1,6 +1,6 @@
 import invariant from "invariant";
 import React, {Component} from "react";
-  import {requireNativeComponent, findNodeHandle} from "react-native";
+import {requireNativeComponent, findNodeHandle, processColor} from "react-native";
 import captureFrame from "./GLCanvas.captureFrame";
 
 const serializeOption = config =>
@@ -114,13 +114,15 @@ class GLCanvas extends Component {
 
   render () {
     const {
-      width, height,
+      width, height, style,
       onLoad, onProgress, eventsThrough,
       ...restProps } = this.props;
+    const { backgroundColor } = style;
 
     return <GLCanvasNative
       ref="native"
       {...restProps}
+      backgroundColor={processColor(backgroundColor)}
       style={{ width, height }}
       onGLLoad={onLoad ? onLoad : null}
       onGLProgress={onProgress ? onProgress : null}


### PR DESCRIPTION
If you want to make backgroundColor transparent on android then you need to pass

```
backgroundColor={'transparent'}
setZOrderOnTop={true}
```
Note that setting `setZOrderOnTop={true}` will change zIndex of Surface and it will appear on the top of your view (in Z-axis). But this is good hack to make transparent background.
And only set `setZOrderOnTop={true}` when you want to set transparent background, for other colors it will not work.