### PR TITLE
android: mask out only RGB channels of background colour

### DIFF
--- a/android/src/main/java/com/projectseptember/RNGL/GLCanvas.java
+++ b/android/src/main/java/com/projectseptember/RNGL/GLCanvas.java
@@ -265,7 +265,7 @@ public class GLCanvas extends GLSurfaceView
 
     @Override
     public void setBackgroundColor(int color) {
-        super.setBackgroundColor(color);
+        super.setBackgroundColor(color & 0xFFFFFF);
         if (color == Color.TRANSPARENT) {
             this.getHolder().setFormat(PixelFormat.TRANSLUCENT);
         }


### PR DESCRIPTION
Fixes #164. I can't get transparent background to work properly either way (i.e. what #155 should supposedly implement), although this might be tied to the Android version I'm testing with? I'm not sure. Some example code to test with would be useful here.

It seems the main issue however is in setting a 32-bit colour but using a 24-bit pixel format, so this commit masks out only the RGB channels of the 32-bit value to match the RGB_888 PixelFormat. If `color == Color.TRANSPARENT`, that implies the alpha channel is 0 already anyway, so the masking out should be a no-op.