### PR TITLE
Fixed Android build on RN56 and RN57

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.3"
+  compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 25
+  buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : '25.0.3'
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 22
+    targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Hi, this PR makes it possible to use `gl-react-native-v2` on RN56 and RN57.

Initially I tried upgrading to `gl-react-native` v3, but found that `react-native-webgl` doesn't compile on XCode 10. Also the inability to attach a debugger makes it a tough cookie to swallow.
Anyway, I decided to revert back to `gl-react-native-v2` in my project for the time being.
I hope this PR serves other people as well that face the same problems.
cheers