### PR TITLE
Fixed compability with newest Android API 26+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 25
-  buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : '25.0.3'
+  compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 26
+  buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : '26.0.3'
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
+    targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 26
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Its needed to use higher target and compile sdks with tools version 26+ to be compatible with its Android Studio env. which uses newer gradle wrapper versions and Gradle tools as well.