### PR TITLE
Fixed podspect to depend on React-RCTImage

### DIFF
--- a/RNGL.podspec
+++ b/RNGL.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m}"
   s.license      = "MIT"
   s.dependency "React"
+  s.dependency 'React-RCTImage'
 end


### PR DESCRIPTION
Fixes the podspec to work with React Native 0.60 since all of the dependencies were moved into their own pods