### PR TITLE
Use UIManager.getViewManagerConfig

### DIFF
--- a/src/GLCanvas.captureFrame.android.js
+++ b/src/GLCanvas.captureFrame.android.js
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import {NativeModules} from "react-native";
 const {UIManager} = NativeModules;
-const GLCanvas = UIManager.getViewManagerConfig('GLCanvas')
+const GLCanvas = UIManager.getViewManagerConfig('GLCanvas');
 invariant(GLCanvas,
 `gl-react-native: the native module is not available.
 Make sure you have properly configured it.

--- a/src/GLCanvas.captureFrame.android.js
+++ b/src/GLCanvas.captureFrame.android.js
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import {NativeModules} from "react-native";
 const {UIManager} = NativeModules;
-const {GLCanvas} = UIManager;
+const GLCanvas = UIManager.getViewManagerConfig('GLCanvas')
 invariant(GLCanvas,
 `gl-react-native: the native module is not available.
 Make sure you have properly configured it.


### PR DESCRIPTION
Fixes warning

> Accessing view manager configs directly off UIManager via UIManager['GLCanvas'] is no longer supported. Use UIManager.getViewManagerConfig('GLCanvas') instead.
