### PR TITLE
Updated package dependencies to support react-native 0.60.5

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,12 +7,12 @@
   },
   "dependencies": {
     "crypto": "0.0.3",
-    "gl-react": "2.2.8",
+    "gl-react": "^2.0.0",
     "gl-react-blur": "^1.3.0",
     "gl-react-native": "file:..",
     "glsl-transitions": "^2017.1.10",
-    "react": "15.4.2",
-    "react-native": "0.42.0",
+    "react": "16.8.6",
+    "react-native": "0.60.5",
     "react-native-fs": "github:gre/react-native-fs#rn-40",
     "seedrandom": "gre/seedrandom#released"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-react-native",
-  "version": "2.60.0",
+  "version": "2.60.1",
   "description": "OpenGL bindings for react-native to implement complex effects over images and components, in the descriptive VDOM paradigm",
   "repository": {
     "type": "git",
@@ -20,7 +20,8 @@
   "license": "MIT",
   "peerDependencies": {
     "gl-react": "^2.2.4",
-    "react-native": "*"
+    "react-native": "^0.60.5",
+    "react": "^16.8.6"
   },
   "dependencies": {
     "invariant": "2.2.0"

--- a/src/GLCanvas.captureFrame.android.js
+++ b/src/GLCanvas.captureFrame.android.js
@@ -1,6 +1,5 @@
 import invariant from "invariant";
-import {NativeModules} from "react-native";
-const {UIManager} = NativeModules;
+import {UIManager, NativeModules} from "react-native";
 const GLCanvas = UIManager.getViewManagerConfig('GLCanvas');
 invariant(GLCanvas,
 `gl-react-native: the native module is not available.


### PR DESCRIPTION
Hey, [gre](https://github.com/gre), thanks for this great repo!

I encountered a couple of problems trying to get the repository working using the latest build for `react-native`; this mainly came down to issues referring to deprecated constructs in `gl-react` (`PropTypes.any`) and attempting to use `UIManager` from `NativeModules` as opposed to `RN.UIManager`. I've added these changes below.

Thanks!